### PR TITLE
Add applicative versions and return unit

### DIFF
--- a/docs/Debug/Trace.md
+++ b/docs/Debug/Trace.md
@@ -34,4 +34,38 @@ Log any PureScript value to the console for debugging purposes and then
 return a value. This will log the value's underlying representation for
 low-level debugging.
 
+#### `traceAnyA`
+
+``` purescript
+traceAnyA :: forall a b. (Applicative a) => b -> a Unit
+```
+
+Log any PureScript value to the console and return the unit value of the
+Applicative `a`.
+
+#### `traceA`
+
+``` purescript
+traceA :: forall a. (Applicative a) => String -> a Unit
+```
+
+Log a message to the console for debugging purposes and then return the
+unit value of the Applicative `a`.
+
+For example:
+``` purescript
+doSomething = do
+  traceA "Hello"
+  ... some value or computation ...
+```
+
+#### `traceShowA`
+
+``` purescript
+traceShowA :: forall a b. (Show b, Applicative a) => b -> a Unit
+```
+
+Log a `Show`able value to the console for debugging purposes and then
+return the unit value of the Applicative `a`.
+
 

--- a/src/Debug/Trace.purs
+++ b/src/Debug/Trace.purs
@@ -22,3 +22,25 @@ traceShow = traceAny <<< show
 -- | return a value. This will log the value's underlying representation for
 -- | low-level debugging.
 foreign import traceAny :: forall a b. a -> (Unit -> b) -> b
+
+-- | Log any PureScript value to the console and return the unit value of the
+-- | Applicative `a`.
+traceAnyA :: forall a b. (Applicative a) => b -> a Unit
+traceAnyA s = traceAny s \_ -> pure unit
+
+-- | Log a message to the console for debugging purposes and then return the
+-- | unit value of the Applicative `a`.
+-- |
+-- | For example:
+-- | ``` purescript
+-- | doSomething = do
+-- |   traceA "Hello"
+-- |   ... some value or computation ...
+-- | ```
+traceA :: forall a. (Applicative a) => String -> a Unit
+traceA = traceAnyA
+
+-- | Log a `Show`able value to the console for debugging purposes and then
+-- | return the unit value of the Applicative `a`.
+traceShowA :: forall a b. (Show b, Applicative a) => b -> a Unit
+traceShowA = traceAnyA <<< show

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,7 +5,10 @@ import Debug.Trace
 import Control.Monad.Eff
 
 main :: Eff () Unit
-main = trace "Testing" \_ ->
+main = do
+  trace "Testing" \_ ->
   traceShow true \_ ->
   traceAny { x: 10 } \_ ->
   pure unit
+  traceA "Testing"
+  traceAnyA { x: 10 }


### PR DESCRIPTION
This allows for easier debug statement placements without changing the
surrounding code too much, consider:

``` purescript
main :: Eff () Unit
main = do
    traceA "foo"
    traceA "bar"
```

Closes #1
