### PR TITLE
added traceSelf

### DIFF
--- a/docs/Debug/Trace.md
+++ b/docs/Debug/Trace.md
@@ -34,6 +34,14 @@ Log any PureScript value to the console for debugging purposes and then
 return a value. This will log the value's underlying representation for
 low-level debugging.
 
+#### `spy`
+
+``` purescript
+spy :: forall a. a -> a
+```
+
+Log any value and return it
+
 #### `traceAnyA`
 
 ``` purescript

--- a/src/Debug/Trace.purs
+++ b/src/Debug/Trace.purs
@@ -23,6 +23,10 @@ traceShow = traceAny <<< show
 -- | low-level debugging.
 foreign import traceAny :: forall a b. a -> (Unit -> b) -> b
 
+-- | Log any value and return it
+spy :: forall a. a -> a
+spy a = traceAny a \_ -> a
+
 -- | Log any PureScript value to the console and return the unit value of the
 -- | Applicative `a`.
 traceAnyA :: forall a b. (Applicative a) => b -> a Unit

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -18,6 +18,8 @@ main = do
   effRec >>= traceAnyM >>= \r -> do
     traceA r.x
 
+  let dummy = spy { foo: 1, bar: [1, 2] }
+  traceAnyA dummy
   where
   effInt :: Eff () Int
   effInt = pure 0


### PR DESCRIPTION
This can be helpful in something like this 

``` purescript
traceSelf $ 
   "SELECT" 
  <> "* from" 
  <> foo bar
  <> "WHERE" 
  <> baz quux
```

comparing with 

``` purescript
let dummy = 
  "SELECT" 
  <> "* from" 
  <> foo bar 
  <> "WHERE" 
  <> baz quux
in traceAny dummy dummy
```

first is easier to add and remove 
