### PR TITLE
Use util.inspect with depth: null for traceAny on node.js

### DIFF
--- a/src/Debug/Trace.js
+++ b/src/Debug/Trace.js
@@ -1,11 +1,19 @@
-/* global exports, console */
+/* global exports, console, require */
 "use strict";
 
 // module Debug.Trace
 
 exports.traceAny = function (x) {
   return function (k) {
-    console.log(x);
+    // node only recurses two levels into an object before printing
+    // "[object]" for further objects when using console.log()
+    if (require !== undefined) {
+      var util = require("util");
+      console.log(util.inspect(x, { depth: null, colors: true }));
+    } else {
+      console.log(x);
+    }
+
     return k({});
   };
 };


### PR DESCRIPTION
Because currently recursive types without a `Show` instance are pretty much non-printable.
