### PR TITLE
Different approach to require to avoid webpack bundling

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -5,7 +5,7 @@
   "freeze": true,
   "funcscope": true,
   "futurehostile": true,
-  "globalstrict": true,
+  "strict": "global",
   "latedef": true,
   "maxparams": 1,
   "noarg": true,
@@ -15,5 +15,6 @@
   "singleGroups": true,
   "undef": true,
   "unused": true,
-  "eqnull": true
+  "eqnull": true,
+  "predef": ["exports", "console", "module"]
 }

--- a/src/Debug/Trace.js
+++ b/src/Debug/Trace.js
@@ -1,11 +1,10 @@
-/* global exports, console, require */
 "use strict";
 
-// Alias require to prevent webpack or browserify from actually requiring.
-var req = typeof require === "undefined" ? undefined : require;
-var util = req === undefined ? undefined : req("util");
-
 // module Debug.Trace
+
+// Alias require to prevent webpack or browserify from actually requiring.
+var req = typeof module === "undefined" ? undefined : module.require;
+var util = req === undefined ? undefined : req("util");
 
 exports.traceAny = function (x) {
   return function (k) {
@@ -16,7 +15,6 @@ exports.traceAny = function (x) {
     } else {
       console.log(x);
     }
-
     return k({});
   };
 };


### PR DESCRIPTION
This actually resolve #6 at last. Going via `module.require` worked in Affjax, so I've taken the same approach here.

@hdgarrood @jplatte do you know if there's a reason why we can't use `module.require` instead of `require`? Going via `module` should still work in node 6, should it not?
