### PR TITLE
Avoid failing on require("util")

### DIFF
--- a/src/Debug/Trace.js
+++ b/src/Debug/Trace.js
@@ -2,7 +2,13 @@
 
 // Alias require to prevent webpack or browserify from actually requiring.
 var req = typeof module === "undefined" ? undefined : module.require;
-var util = req === undefined ? undefined : req("util");
+var util = (function() {
+  try {
+    return req === undefined ? undefined : req("util");
+  } catch(e) {
+    return undefined;
+  }
+})();
 
 exports.trace = function () {
   return function (x) {


### PR DESCRIPTION
Some bundlers, such as [pax](https://pax.js.org), expose `module.require` but do not find the `util` dependency. This causes an error at runtime.