### PR TITLE
traceTime function for performance debugging

### DIFF
--- a/src/Debug.js
+++ b/src/Debug.js
@@ -34,3 +34,25 @@ exports._debugger = function (f) {
   debugger;
   return f();
 };
+
+var now = (function () {
+  var perf;
+  if (typeof performance !== "undefined") {
+    // In browsers, `performance` is available in the global context
+    perf = performance;
+  } else if (req) {
+    // In Node, `performance` is an export of `perf_hooks`
+    try { perf = req("perf_hooks").performance; }
+    catch(e) { }
+  }
+
+  return (function() { return (perf || Date).now(); });
+})();
+
+exports._traceTime = function(name, f) {
+  var start = now();
+  var res = f();
+  var end = now();
+  console.log(name + " took " + (end - start) + "ms");
+  return res;
+};

--- a/src/Debug.purs
+++ b/src/Debug.purs
@@ -2,6 +2,7 @@ module Debug
   ( class DebugWarning
   , trace
   , traceM
+  , traceTime
   , spy
   , spyWith
   , debugger
@@ -39,6 +40,38 @@ traceM :: forall m a. DebugWarning => Monad m => a -> m Unit
 traceM s = do
   pure unit
   trace s \_ -> pure unit
+
+-- | Measures the time it takes the given function to run and prints it out,
+-- | then returns the function's result. This is handy for diagnosing
+-- | performance problems by wrapping suspected parts of the code in
+-- | `traceTime`.
+-- |
+-- | For example:
+-- | ```purescript
+-- | bunchOfThings =
+-- |   [ traceTime "one" \_ -> one x y
+-- |   , traceTime "two" \_ -> two z
+-- |   , traceTime "three" \_ -> three a b c
+-- |   ]
+-- | ```
+-- |
+-- | Console output would look something like this:
+-- | ```
+-- | one took 3.456ms
+-- | two took 562.0023ms
+-- | three took 42.0111ms
+-- | ```
+-- |
+-- | Note that the timing precision may differ depending on whether the
+-- | Performance API is supported. Where supported (on most modern browsers and
+-- | versions of Node), the Performance API offers timing resolution of 5
+-- | microseconds. Where Performance API is not supported, this function will
+-- | fall back on standard JavaScript Date object, which only offers a
+-- | 1-millisecond resolution.
+traceTime :: forall a. String -> (Unit -> a) -> a
+traceTime = runFn2 _traceTime
+
+foreign import _traceTime :: forall a. Fn2 String (Unit -> a) a
 
 -- | Logs any value and returns it, using a "tag" or key value to annotate the
 -- | traced value. Useful when debugging something in the middle of a


### PR DESCRIPTION
May I offer a contribution of the `traceTime` function, which is intended for performance debugging by surrounding suspicious blocks and measuring their run time.

We've been using this function quite successfully for a while, and I figured why not contribute to the library.

Works much like `trace` itself:

```purs
doSomething x y =
  x + (traceTime "cleverCalc" \_ -> cleverCalc y)
```

Prints out something like:

```
cleverCalc took 300ms
```